### PR TITLE
Fix npx execution and switch to ESM format

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,18 +3,21 @@
   "workspaces": {
     "": {
       "name": "gh-release-notes",
+      "dependencies": {
+        "@actions/core": "",
+      },
       "devDependencies": {
-        "@biomejs/biome": "latest",
-        "@octokit/rest": "latest",
-        "@types/pino-std-serializers": "latest",
-        "esbuild": "latest",
-        "jest": "latest",
-        "js-yaml": "latest",
-        "nock": "latest",
-        "oxlint": "latest",
-        "oxlint-tsgolint": "latest",
+        "@biomejs/biome": "^2.2.5",
+        "@octokit/rest": "^22.0.0",
+        "@types/pino-std-serializers": "^4.0.0",
+        "esbuild": "^0.25.10",
+        "jest": "30.2.0",
+        "js-yaml": "^4.1.0",
+        "nock": "^14.0.10",
+        "oxlint": "^1.19.0",
+        "oxlint-tsgolint": "^0.2.0",
         "release-drafter": "github:release-drafter/release-drafter#v6.1.0",
-        "typescript": "latest",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -22,6 +25,8 @@
     "@actions/core": "file:shims/actions-core",
   },
   "packages": {
+    "@actions/core": ["@actions/core@file:shims/actions-core", {}],
+
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.4", "", {}, "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw=="],

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "gh-release-notes": "dist/cli.cjs"
   },
   "scripts": {
-    "build:lib": "esbuild src/core.ts --bundle --platform=node --format=cjs --target=node22 --external:@actions/core --outfile=dist/index.cjs",
-    "build:cli": "esbuild src/cli.ts --bundle --platform=node --format=cjs --target=node22 --external:@actions/core --outfile=dist/cli.cjs",
+    "build:lib": "bun build src/core.ts --target=node --format=cjs --outfile=dist/index.cjs",
+    "build:cli": "bun build src/cli.ts --target=node --format=cjs --outfile=dist/cli.cjs",
     "build": "bun run build:lib && bun run build:cli",
     "prepublishOnly": "bun run build",
     "test": "bun run build && bun test",
@@ -43,5 +43,8 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@actions/core": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "@actionutils/gh-release-notes",
   "version": "0.0.0",
   "description": "PR-based release notes generator. Release-drafter compatible CLI using release-drafter internals.",
-  "type": "commonjs",
-  "main": "dist/index.cjs",
+  "type": "module",
+  "main": "dist/index.js",
   "exports": {
-    ".": "./dist/index.cjs"
+    ".": "./dist/index.js"
   },
   "bin": {
-    "gh-release-notes": "dist/cli.cjs"
+    "gh-release-notes": "dist/cli.js"
   },
   "scripts": {
-    "build:lib": "bun build src/core.ts --target=node --format=cjs --outfile=dist/index.cjs",
-    "build:cli": "bun build src/cli.ts --target=node --format=cjs --outfile=dist/cli.cjs",
+    "build:lib": "bun build src/core.ts --target=node --outfile=dist/index.js",
+    "build:cli": "bun build src/cli.ts --target=node --outfile=dist/cli.js",
     "build": "bun run build:lib && bun run build:cli",
     "prepublishOnly": "bun run build",
     "test": "bun run build && bun test",

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,10 +1,8 @@
-import { createRequire } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
 import { Octokit } from "@octokit/rest";
 import yaml from "js-yaml";
-const require = createRequire(__filename);
 const {
 	validateSchema,
 }: { validateSchema: any } = require("release-drafter/lib/schema");


### PR DESCRIPTION
## Summary
- Fix npx execution by properly bundling release-drafter dependencies
- Switch from CommonJS to ESM format for build output
- Replace esbuild with bun build for better dependency bundling

## Changes
1. **Fixed bundling issue**: Removed `createRequire` and use direct `require` for release-drafter modules, allowing Bun to properly bundle them
2. **Added @actions/core dependency**: Using the local shim to satisfy release-drafter's dependency
3. **Switched to ESM**: Changed package type to "module" and output .js files instead of .cjs

## Test plan
- [x] Build the package with `bun run build`
- [x] Test CLI locally with `./dist/cli.js --help`
- [ ] Publish to npm and test with `npx @actionutils/gh-release-notes --help`

🤖 Generated with [Claude Code](https://claude.ai/code)