### PR TITLE
fix: add repository field for npm trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/actionutils/gh-release-notes"
   }
 }


### PR DESCRIPTION
ERROR:

npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@actionutils%2fgh-release-notes - Error
verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/actionutils/gh-release-notes" from provenance

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
