### PR TITLE
feat: integrate gh-release-notes into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,15 @@ jobs:
           verify: 'actionutils/create-release-pr'
       - uses: actionutils/create-release-pr@v0
         id: release-pr
+        with:
+          skip-release-notes: true # Use gh-release-notes instead
 
   update-release-pr:
     needs: [release-pr]
     if: fromJSON(needs.release-pr.outputs.release_pr).state == 'release_pr_open'
     runs-on: ubuntu-latest
+    outputs:
+      release_notes: ${{ steps.release-notes.outputs.notes }}
     permissions:
       contents: write
       pull-requests: write
@@ -53,6 +57,39 @@ jobs:
           ref: ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_branch }}
           persist-credentials: false
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+
+      - id: release-notes
+        env:
+          PREV_TAG: ${{ fromJSON(needs.release-pr.outputs.release_pr).current_tag }}
+          TAG: ${{ fromJSON(needs.release-pr.outputs.release_pr).next_tag }}
+        run: |
+          RELEASE_NOTES=$(bun run dev --repo "$GITHUB_REPOSITORY" \
+            --target main \
+            --prev-tag "$PREV_TAG" \
+            --tag "$TAG")
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Verify actionutils/sticky-comment
+        uses: actionutils/trusted-tag-verifier@68bef2f18f8ceb5c4dccc5542cadcfbc82ed4656 # v0.5.0
+        with:
+          verify: 'actionutils/sticky-comment'
+
+      - name: Post release notes
+        if: steps.release-notes.outputs.notes != ''
+        uses: actionutils/sticky-comment@v1
+        with:
+          key: 'release-notes'
+          number: ${{ fromJSON(needs.release-pr.outputs.release_pr).pr_number }}
+          body: |
+            ## Release Notes
+            ${{ steps.release-notes.outputs.notes }}
+
       # Post Dependency Review
       - uses: actions/dependency-review-action@v4
         if: fromJSON(needs.release-pr.outputs.release_pr).current_tag != ''
@@ -60,10 +97,6 @@ jobs:
         with:
           base-ref: ${{ fromJSON(needs.release-pr.outputs.release_pr).current_tag }}
           head-ref: main
-      - name: Verify actionutils/sticky-comment
-        uses: actionutils/trusted-tag-verifier@68bef2f18f8ceb5c4dccc5542cadcfbc82ed4656 # v0.5.0
-        with:
-          verify: 'actionutils/sticky-comment'
       - name: Post sticky comment
         if: fromJSON(needs.release-pr.outputs.release_pr).current_tag != ''
         uses: actionutils/sticky-comment@v1
@@ -77,10 +110,6 @@ jobs:
               <summary>Dependency Changes (JSON)</summary>
               <pre>${{ toJSON(fromJSON(steps.dependency-review.outputs.dependency-changes)) }}</pre>
             </details>
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: .bun-version
 
       - uses: actionutils/trusted-tag-verifier@68bef2f18f8ceb5c4dccc5542cadcfbc82ed4656 # v0.5.0
         with:
@@ -145,6 +174,7 @@ jobs:
     with:
       environment: release
       setup-bun: true
+      release-notes: ${{ needs.update-release-pr.outputs.release_notes }}
 
   publish:
     needs: [release-pr, release]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "biome format --write src",
     "format:check": "biome format src",
     "check": "bun run lint && bun run format:check && bun run test",
-    "dev": "bun run build && node dist/cli.cjs",
+    "dev": "bun run src/cli.ts",
     "clean": "rm -rf dist",
     "typecheck": "bunx tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- Set up gh-release-notes output capture in update-release-pr job
- Add sticky-comment to post generated release notes to PR
- Pass generated release notes to trusted-go-releaser workflow for GitHub release

## Test plan
- [ ] Verify release PR workflow runs successfully
- [ ] Check that release notes are properly generated and posted to PR
- [ ] Confirm release notes are passed to the release job

🤖 Generated with [Claude Code](https://claude.ai/code)