### PR TITLE
use gh release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           bun-version-file: .bun-version
 
+      - run: bun install
 
       - id: release-notes
         env:


### PR DESCRIPTION
- **use bun run for `bun run dev`**
- **feat: integrate gh-release-notes into release workflow**
- **run bun install before bun run dev**
