### PR TITLE
feat: Use GitHub-style change template format

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared constants used across the application
+ */
+
+/**
+ * GitHub-style change template that matches GitHub's official release notes format
+ */
+export const GITHUB_STYLE_CHANGE_TEMPLATE = '- $TITLE by @$AUTHOR in #$NUMBER';
+
+/**
+ * Default template for release notes body
+ */
+export const DEFAULT_RELEASE_TEMPLATE =
+	"## What's Changed\n\n$CHANGES\n\n**Full Changelog**: $FULL_CHANGELOG_LINK";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@
 /**
  * GitHub-style change template that matches GitHub's official release notes format
  */
-export const GITHUB_STYLE_CHANGE_TEMPLATE = '- $TITLE by @$AUTHOR in #$NUMBER';
+export const GITHUB_STYLE_CHANGE_TEMPLATE = "- $TITLE by @$AUTHOR in #$NUMBER";
 
 /**
  * Default template for release notes body

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,6 +4,7 @@ import { execSync } from "node:child_process";
 import { Octokit } from "@octokit/rest";
 import yaml from "js-yaml";
 import { normalizeConfig } from "./github-config-converter";
+import { GITHUB_STYLE_CHANGE_TEMPLATE, DEFAULT_RELEASE_TEMPLATE } from "./constants";
 const {
 	validateSchema,
 }: { validateSchema: any } = require("release-drafter/lib/schema");
@@ -20,8 +21,6 @@ const {
 	findReleases: any;
 } = require("release-drafter/lib/releases");
 
-const DEFAULT_FALLBACK_TEMPLATE =
-	"## What's Changed\n\n$CHANGES\n\n**Full Changelog**: $FULL_CHANGELOG_LINK";
 
 export type RunOptions = {
 	repo: string;
@@ -202,7 +201,10 @@ export async function run(options: RunOptions) {
 			const raw = fs.readFileSync(githubReleasePath, "utf8");
 			cfg = parseConfigString(raw, githubReleasePath);
 		} else {
-			cfg = { template: DEFAULT_FALLBACK_TEMPLATE };
+			cfg = {
+				template: DEFAULT_RELEASE_TEMPLATE,
+				'change-template': GITHUB_STYLE_CHANGE_TEMPLATE
+			};
 		}
 	}
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,7 +4,10 @@ import { execSync } from "node:child_process";
 import { Octokit } from "@octokit/rest";
 import yaml from "js-yaml";
 import { normalizeConfig } from "./github-config-converter";
-import { GITHUB_STYLE_CHANGE_TEMPLATE, DEFAULT_RELEASE_TEMPLATE } from "./constants";
+import {
+	GITHUB_STYLE_CHANGE_TEMPLATE,
+	DEFAULT_RELEASE_TEMPLATE,
+} from "./constants";
 const {
 	validateSchema,
 }: { validateSchema: any } = require("release-drafter/lib/schema");
@@ -20,7 +23,6 @@ const {
 	generateReleaseInfo: any;
 	findReleases: any;
 } = require("release-drafter/lib/releases");
-
 
 export type RunOptions = {
 	repo: string;
@@ -142,7 +144,7 @@ async function getGitHubToken(providedToken?: string): Promise<string> {
 	try {
 		const token = execSync("gh auth token", { encoding: "utf8" }).trim();
 		if (token) return token;
-	} catch (error) {
+	} catch {
 		// gh auth token failed, fall through to error
 	}
 
@@ -203,7 +205,7 @@ export async function run(options: RunOptions) {
 		} else {
 			cfg = {
 				template: DEFAULT_RELEASE_TEMPLATE,
-				'change-template': GITHUB_STYLE_CHANGE_TEMPLATE
+				"change-template": GITHUB_STYLE_CHANGE_TEMPLATE,
 			};
 		}
 	}

--- a/src/github-config-converter.ts
+++ b/src/github-config-converter.ts
@@ -3,7 +3,10 @@
  */
 
 import { logVerbose, logWarning } from "./logger";
-import { GITHUB_STYLE_CHANGE_TEMPLATE, DEFAULT_RELEASE_TEMPLATE } from "./constants";
+import {
+	GITHUB_STYLE_CHANGE_TEMPLATE,
+	DEFAULT_RELEASE_TEMPLATE,
+} from "./constants";
 
 interface GitHubReleaseCategory {
 	title: string;
@@ -120,8 +123,8 @@ export function convertGitHubToReleaseDrafter(
 	}
 
 	// Set GitHub-style change-template
-	if (!releaseDrafterConfig['change-template']) {
-		releaseDrafterConfig['change-template'] = GITHUB_STYLE_CHANGE_TEMPLATE;
+	if (!releaseDrafterConfig["change-template"]) {
+		releaseDrafterConfig["change-template"] = GITHUB_STYLE_CHANGE_TEMPLATE;
 	}
 
 	return releaseDrafterConfig;

--- a/src/github-config-converter.ts
+++ b/src/github-config-converter.ts
@@ -3,6 +3,7 @@
  */
 
 import { logVerbose, logWarning } from "./logger";
+import { GITHUB_STYLE_CHANGE_TEMPLATE, DEFAULT_RELEASE_TEMPLATE } from "./constants";
 
 interface GitHubReleaseCategory {
 	title: string;
@@ -112,11 +113,15 @@ export function convertGitHubToReleaseDrafter(
 		);
 	}
 
-	// Set a default template if not provided
+	// Set a default template and change-template if not provided
 	// This matches the default behavior of GitHub's release notes
 	if (!releaseDrafterConfig.template) {
-		releaseDrafterConfig.template =
-			"## What's Changed\n\n$CHANGES\n\n**Full Changelog**: $FULL_CHANGELOG_LINK";
+		releaseDrafterConfig.template = DEFAULT_RELEASE_TEMPLATE;
+	}
+
+	// Set GitHub-style change-template
+	if (!releaseDrafterConfig['change-template']) {
+		releaseDrafterConfig['change-template'] = GITHUB_STYLE_CHANGE_TEMPLATE;
 	}
 
 	return releaseDrafterConfig;


### PR DESCRIPTION
## Summary
- Changes the default change-template to match GitHub's official release notes format: `- $TITLE by @$AUTHOR in #$NUMBER`
- Extracts shared constants to eliminate code duplication
- Provides better consistency with GitHub's native release notes generation

## Changes
- Created new `constants.ts` file with shared template constants
- Updated `core.ts` to use the shared constants
- Updated `github-config-converter.ts` to use the shared constants
- Both default config and GitHub config converter now use the same GitHub-style format

## Test plan
- [x] Build the project successfully (`npm run build`)
- [x] All tests pass (`npm test`)
- [x] Verified the output format matches GitHub style with test command

🤖 Generated with [Claude Code](https://claude.ai/code)