### PR TITLE
use dev dependencies for yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,15 @@
     "@biomejs/biome": "^2.2.5",
     "@octokit/rest": "^22.0.0",
     "@types/pino-std-serializers": "^4.0.0",
+    "@types/yargs": "^17.0.33",
     "jest": "30.2.0",
     "js-yaml": "^4.1.0",
     "nock": "^14.0.10",
     "oxlint": "^1.19.0",
     "oxlint-tsgolint": "^0.2.0",
     "release-drafter": "github:release-drafter/release-drafter#v6.1.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "yargs": "^18.0.0"
   },
   "engines": {
     "node": ">=22.0.0"
@@ -49,7 +51,5 @@
     "url": "https://github.com/actionutils/gh-release-notes"
   },
   "dependencies": {
-    "@types/yargs": "^17.0.33",
-    "yargs": "^18.0.0"
   }
 }


### PR DESCRIPTION
follow up of https://github.com/actionutils/gh-release-notes/pull/29
