### PR TITLE
feat: Add default category template for GitHub-style formatting

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,21 @@
 export const GITHUB_STYLE_CHANGE_TEMPLATE = "- $TITLE by @$AUTHOR in #$NUMBER";
 
 /**
+ * GitHub-style category template that matches GitHub's official release notes format
+ */
+export const GITHUB_STYLE_CATEGORY_TEMPLATE = "### $TITLE";
+
+/**
  * Default template for release notes body
  */
 export const DEFAULT_RELEASE_TEMPLATE =
 	"## What's Changed\n\n$CHANGES\n\n**Full Changelog**: $FULL_CHANGELOG_LINK";
+
+/**
+ * Default fallback config for release-drafter when no config is provided
+ */
+export const DEFAULT_FALLBACK_CONFIG = {
+	template: DEFAULT_RELEASE_TEMPLATE,
+	"change-template": GITHUB_STYLE_CHANGE_TEMPLATE,
+	"category-template": GITHUB_STYLE_CATEGORY_TEMPLATE,
+};

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,10 +4,7 @@ import { execSync } from "node:child_process";
 import { Octokit } from "@octokit/rest";
 import yaml from "js-yaml";
 import { normalizeConfig } from "./github-config-converter";
-import {
-	GITHUB_STYLE_CHANGE_TEMPLATE,
-	DEFAULT_RELEASE_TEMPLATE,
-} from "./constants";
+import { DEFAULT_FALLBACK_CONFIG } from "./constants";
 const {
 	validateSchema,
 }: { validateSchema: any } = require("release-drafter/lib/schema");
@@ -210,10 +207,7 @@ export async function run(options: RunOptions) {
 			const raw = fs.readFileSync(githubReleaseYamlPath, "utf8");
 			cfg = parseConfigString(raw, githubReleaseYamlPath);
 		} else {
-			cfg = {
-				template: DEFAULT_RELEASE_TEMPLATE,
-				"change-template": GITHUB_STYLE_CHANGE_TEMPLATE,
-			};
+			cfg = DEFAULT_FALLBACK_CONFIG;
 		}
 	}
 

--- a/src/github-config-converter.ts
+++ b/src/github-config-converter.ts
@@ -3,10 +3,7 @@
  */
 
 import { logVerbose, logWarning } from "./logger";
-import {
-	GITHUB_STYLE_CHANGE_TEMPLATE,
-	DEFAULT_RELEASE_TEMPLATE,
-} from "./constants";
+import { DEFAULT_FALLBACK_CONFIG } from "./constants";
 
 interface GitHubReleaseCategory {
 	title: string;
@@ -62,7 +59,10 @@ export function isGitHubReleaseConfig(
 export function convertGitHubToReleaseDrafter(
 	githubConfig: GitHubReleaseConfig,
 ): ReleaseDrafterConfig {
-	const releaseDrafterConfig: ReleaseDrafterConfig = {};
+	// Start with the default fallback config as base
+	const releaseDrafterConfig: ReleaseDrafterConfig = {
+		...DEFAULT_FALLBACK_CONFIG,
+	};
 
 	// Convert excluded labels
 	if (githubConfig.changelog.exclude?.labels) {
@@ -114,17 +114,6 @@ export function convertGitHubToReleaseDrafter(
 				return rdCategory;
 			},
 		);
-	}
-
-	// Set a default template and change-template if not provided
-	// This matches the default behavior of GitHub's release notes
-	if (!releaseDrafterConfig.template) {
-		releaseDrafterConfig.template = DEFAULT_RELEASE_TEMPLATE;
-	}
-
-	// Set GitHub-style change-template
-	if (!releaseDrafterConfig["change-template"]) {
-		releaseDrafterConfig["change-template"] = GITHUB_STYLE_CHANGE_TEMPLATE;
 	}
 
 	return releaseDrafterConfig;


### PR DESCRIPTION
## Summary
- Added default `category-template: ### $TITLE` to match GitHub's official release notes format
- Centralized default config settings into a single `DEFAULT_FALLBACK_CONFIG` constant
- Applied consistent formatting for both fallback configs and GitHub release.yml conversions

## Test plan
- [x] All existing tests pass (22 tests)
- [x] Default category template is applied when no config is provided
- [x] GitHub release.yml conversion inherits the default templates

🤖 Generated with [Claude Code](https://claude.ai/code)