### PR TITLE
Disable bun build --compile --bytecode

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,8 @@ builds:
     flags:
       - --compile
       - --minify
-      - --bytecode
+      # Disable --bytecode
+      # - --bytecode
 
 archives:
   - id: binary


### PR DESCRIPTION
It doesn't work with the following error.

Error:
```
 6 |     "use strict";
 7 |
 8 |     //
 9 |     if (entry.instantiate)
10 |         return entry.instantiate;
11 |     var instantiatePromise = (async () => {
                                               ^
TypeError: Expected CommonJS module to have a function wrapper. If you weren't messing around with Bun's internals, this is a bug in Bun
```