### PR TITLE
fix: suppress wildcard warning by default (fixes #40)

### DIFF
--- a/src/github-config-converter.test.ts
+++ b/src/github-config-converter.test.ts
@@ -273,7 +273,9 @@ describe("GitHub Config Converter", () => {
 
 			expect(stderrOutput).toContain("Other Changes");
 			// No longer expect "Warning:" prefix since it's now a verbose log
-			expect(stderrOutput).toContain("has exclusions which are not directly supported");
+			expect(stderrOutput).toContain(
+				"has exclusions which are not directly supported",
+			);
 		});
 	});
 

--- a/src/github-config-converter.test.ts
+++ b/src/github-config-converter.test.ts
@@ -237,6 +237,12 @@ describe("GitHub Config Converter", () => {
 		});
 
 		it("should warn about category-level exclusions", () => {
+			// Import setVerbose
+			const { setVerbose } = require("./logger");
+
+			// Enable verbose mode for this test
+			setVerbose(true);
+
 			// Capture stderr output
 			const originalStderr = process.stderr.write.bind(process.stderr);
 			let stderrOutput = "";
@@ -261,11 +267,13 @@ describe("GitHub Config Converter", () => {
 
 			convertGitHubToReleaseDrafter(githubConfig);
 
-			// Restore stderr
+			// Restore stderr and verbose mode
 			process.stderr.write = originalStderr;
+			setVerbose(false);
 
 			expect(stderrOutput).toContain("Other Changes");
-			expect(stderrOutput).toContain("Warning:");
+			// No longer expect "Warning:" prefix since it's now a verbose log
+			expect(stderrOutput).toContain("has exclusions which are not directly supported");
 		});
 	});
 

--- a/src/github-config-converter.ts
+++ b/src/github-config-converter.ts
@@ -2,7 +2,7 @@
  * Converts GitHub's official release.yml format to release-drafter format
  */
 
-import { logVerbose, logWarning } from "./logger";
+import { logVerbose } from "./logger";
 import { DEFAULT_FALLBACK_CONFIG } from "./constants";
 
 interface GitHubReleaseCategory {
@@ -102,7 +102,7 @@ export function convertGitHubToReleaseDrafter(
 				// However, for wildcard categories, release-drafter's behavior of only including
 				// uncategorized items effectively provides similar filtering
 				if (category.exclude?.labels || category.exclude?.authors) {
-					logWarning(
+					logVerbose(
 						`Category "${category.title}" has exclusions which are not directly supported by release-drafter. ` +
 							"Global exclusions will be applied instead. " +
 							(category.labels?.includes("*")


### PR DESCRIPTION
## Summary
- Changed the wildcard category exclusion warning from `logWarning` to `logVerbose`
- Warning now only appears when the `--verbose` flag is used
- Updated test to enable verbose mode when testing for the warning

## Motivation
As reported in #40, the warning about wildcard categories with exclusions appears frequently and adds noise to the output, even though the tool preserves the correct behavior. This change suppresses the warning by default while still making it available for debugging with the `--verbose` flag.

## Test plan
- All existing tests pass
- Manual testing confirms warning is suppressed without `--verbose` flag
- Manual testing confirms warning appears with `--verbose` flag

Fixes #40

🤖 Generated with [Claude Code](https://claude.ai/code)