### PR TITLE
feat(json): include minimal contributors with avatars

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,6 +186,7 @@ async function main() {
 						defaultBranch: result.defaultBranch,
 						lastRelease: result.lastRelease,
 						mergedPullRequests: result.pullRequests,
+						contributors: result.contributors,
 						newContributors: shapedNewContributors,
 						release: allowlistedRelease,
 					},

--- a/src/contributors.ts
+++ b/src/contributors.ts
@@ -5,6 +5,7 @@ export type ContributorWithAvatar = {
 	login: string;
 	isBot: boolean;
 	avatar_url: string;
+	html_url: string;
 };
 
 // Build minimal contributors list from merged PRs
@@ -39,13 +40,20 @@ export async function enrichContributorAvatars(
 	contributors: MinimalContributor[],
 	rest: (pathname: string) => Promise<any>,
 ): Promise<ContributorWithAvatar[]> {
-	const result: ContributorWithAvatar[] = contributors.map((c) => ({
-		login: c.login,
-		isBot: c.isBot,
-		avatar_url: c.isBot
-			? ""
-			: `https://github.com/${encodeURIComponent(c.login)}.png?size=64`,
-	}));
+	const result: ContributorWithAvatar[] = contributors.map((c) => {
+		const isBot = c.isBot;
+		const login = c.login;
+		const baseUserUrl = `https://github.com/${encodeURIComponent(login)}`;
+		const appLogin = login.replace(/\[bot\]$/i, "");
+		const baseAppUrl = `https://github.com/apps/${encodeURIComponent(appLogin)}`;
+
+		return {
+			login,
+			isBot,
+			avatar_url: isBot ? "" : `${baseUserUrl}.png?size=64`,
+			html_url: isBot ? baseAppUrl : baseUserUrl,
+		};
+	});
 
 	const botContributors = result.filter((c) => c.isBot);
 	if (botContributors.length === 0) return result;

--- a/src/contributors.ts
+++ b/src/contributors.ts
@@ -1,0 +1,70 @@
+import { logVerbose } from "./logger";
+
+export type MinimalContributor = { login: string; isBot: boolean };
+export type ContributorWithAvatar = {
+	login: string;
+	isBot: boolean;
+	avatar_url: string;
+};
+
+// Build minimal contributors list from merged PRs
+export function buildMinimalContributors(
+	pullRequests: any[] | undefined,
+	excludeContributors: string[] = [],
+): MinimalContributor[] {
+	const flags = new Map<string, MinimalContributor>();
+	for (const pr of pullRequests || []) {
+		const login = pr.author?.login as string | undefined;
+		if (!login) continue;
+		const isBot = pr.author?.__typename === "Bot";
+		if (!flags.has(login)) {
+			flags.set(login, { login, isBot });
+		}
+	}
+	const result = Array.from(flags.values())
+		.filter((c) => !excludeContributors.includes(c.login))
+		.sort((a, b) => a.login.localeCompare(b.login));
+	logVerbose(`[Contributors] Collected ${result.length} unique contributors`);
+	return result;
+}
+
+// NOTE: Ideally we should modify release-drafter's GraphQL query to include
+// PR author avatarUrl and avoid any extra calls. However, GitHub's GraphQL API
+// cannot resolve Bot accounts by login (user/search), so as a pragmatic
+// workaround we resolve avatars for Bot contributors via REST
+//   GET /users/{login%5Bbot%5D}
+// Non-bot contributors use a deterministic avatar URL pattern that does not
+// require API calls.
+export async function enrichContributorAvatars(
+	contributors: MinimalContributor[],
+	rest: (pathname: string) => Promise<any>,
+): Promise<ContributorWithAvatar[]> {
+	const result: ContributorWithAvatar[] = contributors.map((c) => ({
+		login: c.login,
+		isBot: c.isBot,
+		avatar_url: c.isBot
+			? ""
+			: `https://github.com/${encodeURIComponent(c.login)}.png?size=64`,
+	}));
+
+	const botContributors = result.filter((c) => c.isBot);
+	if (botContributors.length === 0) return result;
+
+	await Promise.all(
+		botContributors.map(async (c) => {
+			try {
+				const loginForRest = /\[bot\]$/i.test(c.login)
+					? c.login
+					: `${c.login}[bot]`;
+				const user = await rest(`/users/${encodeURIComponent(loginForRest)}`);
+				let url = String(user.avatar_url || "");
+				url += url.includes("?") ? "&s=64" : "?s=64";
+				c.avatar_url = url;
+			} catch {
+				// Leave empty if not resolvable; callers can decide how to handle it
+			}
+		}),
+	);
+
+	return result;
+}

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -64,9 +64,6 @@ describe("actionutils/gh-release-notes core", () => {
 			}
 
 			// GraphQL endpoint for PR data
-
-			// (no REST fallback for avatars)
-
 			if (u.includes("/graphql")) {
 				return {
 					ok: true,

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -64,6 +64,9 @@ describe("actionutils/gh-release-notes core", () => {
 			}
 
 			// GraphQL endpoint for PR data
+
+			// (no REST fallback for avatars)
+
 			if (u.includes("/graphql")) {
 				return {
 					ok: true,
@@ -526,6 +529,22 @@ describe("actionutils/gh-release-notes core", () => {
 				}
 			}
 
+			// REST for bot avatar (placed outside GraphQL condition)
+			if (u.endsWith("/users/github-actions%5Bbot%5D")) {
+				const user = {
+					login: "github-actions[bot]",
+					avatar_url: "https://avatars.githubusercontent.com/in/15368?v=4",
+					type: "Bot",
+				};
+				return {
+					ok: true,
+					status: 200,
+					headers: new Map([["content-type", "application/json"]]),
+					json: async () => user,
+					text: async () => JSON.stringify(user),
+				};
+			}
+
 			throw new Error("Unexpected fetch: " + u);
 		}) as any;
 
@@ -545,6 +564,15 @@ describe("actionutils/gh-release-notes core", () => {
 				"github-actions",
 			);
 			expect(res.newContributors?.newContributors[0].isBot).toBe(true);
+
+			// Should include minimal contributors list in run() result
+			expect(res.contributors).toBeDefined();
+			expect(res.contributors.length).toBe(1);
+			expect(res.contributors[0].login).toBe("github-actions");
+			expect(res.contributors[0].isBot).toBe(true);
+			expect(res.contributors[0].avatar_url).toBe(
+				"https://avatars.githubusercontent.com/in/15368?v=4&s=64",
+			);
 		} finally {
 			// Cleanup
 			await fsPromises.rm(tmpDir, { recursive: true });

--- a/src/core.ts
+++ b/src/core.ts
@@ -430,23 +430,26 @@ export async function run(options: RunOptions) {
 		(pathname) => ghRest(pathname, { token }),
 	);
 
-    // Transform new contributors data for JSON output (remove internal details)
-    // Also attach avatar_url by reusing the already-resolved contributors list
-    const avatarMap = new Map<string, string>();
-    for (const c of contributors) {
-        if (c.avatar_url) avatarMap.set(c.login, c.avatar_url);
-    }
-    const newContributorsOutput = newContributorsData
-        ? {
-                newContributors: newContributorsData.newContributors.map((c) => ({
-                    login: c.login,
-                    isBot: c.isBot,
-                    firstPullRequest: c.firstPullRequest,
-                    avatar_url: avatarMap.get(c.login),
-                })),
-                totalContributors: newContributorsData.totalContributors,
-            }
-        : null;
+	// Transform new contributors data for JSON output (remove internal details)
+	// Also attach avatar_url/html_url by reusing the already-resolved contributors list
+	const avatarMap = new Map<string, string>();
+	const htmlMap = new Map<string, string>();
+	for (const c of contributors) {
+		if (c.avatar_url) avatarMap.set(c.login, c.avatar_url);
+		if ((c as any).html_url) htmlMap.set(c.login, (c as any).html_url);
+	}
+	const newContributorsOutput = newContributorsData
+		? {
+				newContributors: newContributorsData.newContributors.map((c) => ({
+					login: c.login,
+					isBot: c.isBot,
+					firstPullRequest: c.firstPullRequest,
+					avatar_url: avatarMap.get(c.login),
+					html_url: htmlMap.get(c.login),
+				})),
+				totalContributors: newContributorsData.totalContributors,
+			}
+		: null;
 
 	logVerbose("[Run] Completed successfully");
 	return {

--- a/src/core.ts
+++ b/src/core.ts
@@ -430,17 +430,23 @@ export async function run(options: RunOptions) {
 		(pathname) => ghRest(pathname, { token }),
 	);
 
-	// Transform new contributors data for JSON output (remove internal details)
-	const newContributorsOutput = newContributorsData
-		? {
-				newContributors: newContributorsData.newContributors.map((c) => ({
-					login: c.login,
-					isBot: c.isBot,
-					firstPullRequest: c.firstPullRequest,
-				})),
-				totalContributors: newContributorsData.totalContributors,
-			}
-		: null;
+    // Transform new contributors data for JSON output (remove internal details)
+    // Also attach avatar_url by reusing the already-resolved contributors list
+    const avatarMap = new Map<string, string>();
+    for (const c of contributors) {
+        if (c.avatar_url) avatarMap.set(c.login, c.avatar_url);
+    }
+    const newContributorsOutput = newContributorsData
+        ? {
+                newContributors: newContributorsData.newContributors.map((c) => ({
+                    login: c.login,
+                    isBot: c.isBot,
+                    firstPullRequest: c.firstPullRequest,
+                    avatar_url: avatarMap.get(c.login),
+                })),
+                totalContributors: newContributorsData.totalContributors,
+            }
+        : null;
 
 	logVerbose("[Run] Completed successfully");
 	return {

--- a/src/types/new-contributors.ts
+++ b/src/types/new-contributors.ts
@@ -23,10 +23,11 @@ export interface NewContributor extends Contributor {
 
 // Simplified version for JSON output (without internal details)
 export interface NewContributorOutput {
-    login: string;
-    isBot: boolean;
-    firstPullRequest: PullRequestInfo;
-    avatar_url?: string;
+	login: string;
+	isBot: boolean;
+	firstPullRequest: PullRequestInfo;
+	avatar_url?: string;
+	html_url?: string;
 }
 
 export interface ContributorCheckResult {

--- a/src/types/new-contributors.ts
+++ b/src/types/new-contributors.ts
@@ -23,9 +23,10 @@ export interface NewContributor extends Contributor {
 
 // Simplified version for JSON output (without internal details)
 export interface NewContributorOutput {
-	login: string;
-	isBot: boolean;
-	firstPullRequest: PullRequestInfo;
+    login: string;
+    isBot: boolean;
+    firstPullRequest: PullRequestInfo;
+    avatar_url?: string;
 }
 
 export interface ContributorCheckResult {


### PR DESCRIPTION
- Add contributors array to --json output with minimal fields: {login, isBot, avatar_url}
- Resolve avatars:
  - Non-bot: deterministic https://github.com/<login>.png?size=64 (no extra API)
  - Bot: REST GET /users/{login%5Bbot%5D} and append &s=64
- Factor logic into src/contributors.ts (buildMinimalContributors, enrichContributorAvatars)
- Wire into core run() and keep exclude-contributors filter and sorting
- Tests: adapt to REST bot avatar lookup

NOTE: Ideally release-drafter should include author.avatarUrl in its GraphQL query. GraphQL cannot resolve bot accounts by login, so this is a pragmatic workaround using REST for bots; we may upstream a fix, fork, or handle it fully on gh-release-notes later.
