### PR TITLE
feat(json): add categorizedPullRequests to --json output

### DIFF
--- a/src/categorize.ts
+++ b/src/categorize.ts
@@ -1,0 +1,126 @@
+/**
+ * Workaround: Local copy of release-drafter's categorize logic
+ *
+ * This re-implements the categorizePullRequests behavior from
+ * release-drafter v6.1.0 (lib/releases.js) because the function is not
+ * exported upstream. Once upstream exposes a stable API for categorization,
+ * we should replace this file with direct imports to reduce maintenance.
+ */
+
+export type LabelNode = { name: string };
+export type Labels = { nodes: LabelNode[] };
+export type MinimalPullRequest = { labels: Labels } & Record<string, unknown>;
+
+export type Category = {
+	title: string;
+	labels: string[];
+	"collapse-after"?: number;
+	[k: string]: unknown;
+};
+
+export type CategorizeConfig = {
+	"exclude-labels"?: string[];
+	"include-labels"?: string[];
+	categories?: Category[];
+};
+
+export type CategorizedResult<T extends MinimalPullRequest> = {
+	uncategorized: T[];
+	categories: Array<Category & { pullRequests: T[] }>;
+};
+
+function getFilterExcludedPullRequests<T extends MinimalPullRequest>(
+	excludeLabels: string[],
+) {
+	return (pullRequest: T) => {
+		const labels = pullRequest.labels.nodes;
+		if (labels.some((label) => excludeLabels.includes(label.name))) {
+			return false;
+		}
+		return true;
+	};
+}
+
+function getFilterIncludedPullRequests<T extends MinimalPullRequest>(
+	includeLabels: string[],
+) {
+	return (pullRequest: T) => {
+		const labels = pullRequest.labels.nodes;
+		if (
+			includeLabels.length === 0 ||
+			labels.some((label) => includeLabels.includes(label.name))
+		) {
+			return true;
+		}
+		return false;
+	};
+}
+
+/**
+ * Categorize PRs using release-drafter compatible config.
+ * Returns both uncategorized PRs and per-category PR arrays.
+ */
+export function categorizePullRequests<T extends MinimalPullRequest>(
+	pullRequests: T[],
+	config: CategorizeConfig,
+): CategorizedResult<T> {
+	const excludeLabels: string[] = config?.["exclude-labels"] ?? [];
+	const includeLabels: string[] = config?.["include-labels"] ?? [];
+	const categories: Category[] = Array.isArray(config?.categories)
+		? (config.categories as Category[])
+		: [];
+
+	const allCategoryLabels = new Set<string>(
+		categories.flatMap((category) => category.labels || []),
+	);
+
+	const uncategorizedPullRequests: T[] = [];
+	const categorizedPullRequests = [...categories].map((category) => ({
+		...category,
+		pullRequests: [] as T[],
+	}));
+
+	const uncategorizedCategoryIndex = categories.findIndex(
+		(category) => (category.labels?.length ?? 0) === 0,
+	);
+
+	const filterUncategorizedPullRequests = (pullRequest: T) => {
+		const labels = pullRequest.labels.nodes;
+
+		if (
+			labels.length === 0 ||
+			!labels.some((label: any) => allCategoryLabels.has(label.name))
+		) {
+			if (uncategorizedCategoryIndex === -1) {
+				uncategorizedPullRequests.push(pullRequest);
+			} else {
+				categorizedPullRequests[uncategorizedCategoryIndex].pullRequests.push(
+					pullRequest,
+				);
+			}
+			return false;
+		}
+		return true;
+	};
+
+	const filteredPullRequests = pullRequests
+		.filter(getFilterExcludedPullRequests<T>(excludeLabels))
+		.filter(getFilterIncludedPullRequests<T>(includeLabels))
+		.filter((pullRequest) => filterUncategorizedPullRequests(pullRequest));
+
+	for (const category of categorizedPullRequests) {
+		for (const pullRequest of filteredPullRequests) {
+			const labels = pullRequest.labels.nodes;
+			if (
+				labels.some((label) => (category.labels || []).includes(label.name))
+			) {
+				category.pullRequests.push(pullRequest);
+			}
+		}
+	}
+
+	return {
+		uncategorized: uncategorizedPullRequests,
+		categories: categorizedPullRequests,
+	};
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,6 +186,7 @@ async function main() {
 						defaultBranch: result.defaultBranch,
 						lastRelease: result.lastRelease,
 						mergedPullRequests: result.pullRequests,
+						categorizedPullRequests: result.categorizedPullRequests,
 						contributors: result.contributors,
 						newContributors: shapedNewContributors,
 						release: allowlistedRelease,

--- a/src/core.ts
+++ b/src/core.ts
@@ -15,6 +15,11 @@ import {
 	buildMinimalContributors,
 	enrichContributorAvatars,
 } from "./contributors";
+import {
+	categorizePullRequests,
+	type MinimalPullRequest,
+	type CategorizeConfig,
+} from "./categorize";
 const {
 	validateSchema,
 }: { validateSchema: any } = require("release-drafter/lib/schema");
@@ -451,11 +456,18 @@ export async function run(options: RunOptions) {
 			}
 		: null;
 
+	// Build categorized pull requests for JSON output using local workaround
+	const categorizedPullRequests = categorizePullRequests(
+		(data.pullRequests || []) as MinimalPullRequest[],
+		rdConfig as CategorizeConfig,
+	);
+
 	logVerbose("[Run] Completed successfully");
 	return {
 		release: releaseInfo,
 		commits: data.commits,
 		pullRequests: data.pullRequests,
+		categorizedPullRequests,
 		contributors,
 		newContributors: newContributorsOutput,
 		lastRelease: lastRelease


### PR DESCRIPTION
- Implement local categorize.ts as a workaround mirroring release-drafter v6.1.0 logic (not exported upstream)
- Integrate categorization in core and include in CLI --json output
- Refactor categorize to be generic and type-safe, minimizing any

Closes #48
