### PR TITLE
feat: PR-only GraphQL + include-paths via GraphQL files

### DIFF
--- a/docs/pr-only-graphql.md
+++ b/docs/pr-only-graphql.md
@@ -1,0 +1,151 @@
+# Lightweight PR-only GraphQL for Release Notes
+
+## Context
+- Goal: Always use a lightweight PR-only data flow to generate release notes, while staying compatible with release-drafter config/templates.
+- Motivation: Avoid commit history scans and associated GraphQL pagination. Directly fetching merged PRs is significantly lighter. For include-paths, filter PRs by changed files via GraphQL in batched queries (no fallback).
+
+## Baseline (for reference)
+- release-drafter internals typically do:
+  - findReleases → detect previous release.
+  - findCommitsWithAssociatedPullRequests → GraphQL commit history scan + PR association.
+  - sortPullRequests → ordering by mergedAt/title.
+  - generateReleaseInfo → builds body ($CHANGES, $CONTRIBUTORS, etc.).
+- This repo already adds:
+  - New contributors detection via separate batched GraphQL searches.
+  - Contributors avatar enrichment (REST for bots, deterministic URL for users).
+
+## Problem
+- Commit history scanning is heavy. We only need merged PRs in the period since the previous release for most templates and outputs.
+
+## Design Overview
+
+### 1) PR-only fetch (GraphQL search)
+- Use GraphQL search scoped to repo and merged PRs, bounded by previous release timestamp when available.
+- Query string: `repo:OWNER/REPO is:pr is:merged merged:>ISO_TIMESTAMP` (strictly greater to mirror RD logic). If no previous release, see Edge Cases.
+- Fields (conditionally included based on template needs to stay light):
+  - Core: `number`, `title`, `mergedAt`, `labels(first: 100) { nodes { name } }`, `author { login __typename url ... }`
+  - Optional: `body` ($BODY), `url` ($URL), `baseRefName` ($BASE_REF_NAME), `headRefName` ($HEAD_REF_NAME)
+  - Optional user extras (best-effort): `author { ... on User { avatarUrl sponsorsListing { url } } }`
+
+Example (field gating by @include):
+
+```graphql
+query SearchMergedPRs(
+  $q: String!
+  $withBody: Boolean!
+  $withURL: Boolean!
+  $withBase: Boolean!
+  $withHead: Boolean!
+  $after: String
+) {
+  search(query: $q, type: ISSUE, first: 100, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        mergedAt
+        url @include(if: $withURL)
+        body @include(if: $withBody)
+        baseRefName @include(if: $withBase)
+        headRefName @include(if: $withHead)
+        labels(first: 100) { nodes { name } }
+        author {
+          login
+          __typename
+          url
+          ... on User { avatarUrl sponsorsListing { url } }
+        }
+      }
+    }
+  }
+}
+```
+
+### 2) include-paths support via GraphQL batched changed-files
+- When config has `include-paths`, filter the fetched PR set by changed files using the GraphQL `PullRequest.files` connection.
+- Batched query form (aliases per PR number) against the repository:
+
+```graphql
+query FilesForPRs(
+  $owner: String!
+  $name: String!
+  $after_pr1: String
+  $after_pr2: String
+) {
+  repo: repository(owner: $owner, name: $name) {
+    pr1: pullRequest(number: 123) {
+      files(first: 100, after: $after_pr1) {
+        pageInfo { hasNextPage endCursor }
+        nodes { path previousFilePath }
+      }
+    }
+    pr2: pullRequest(number: 456) {
+      files(first: 100, after: $after_pr2) {
+        pageInfo { hasNextPage endCursor }
+        nodes { path previousFilePath }
+      }
+    }
+  }
+}
+```
+
+- We chunk PRs (e.g., 20–40 per query) to respect complexity limits.
+- For PRs with `hasNextPage`, we loop with per-PR cursors until all files are retrieved or a match is found (early-exit per PR when matched to save cost).
+- Matching semantics:
+  - Treat `include-paths` entries as path prefixes from repo root.
+  - A PR is included if any `path` (or `previousFilePath`) starts with any configured include-path.
+- No REST fallback; if GraphQL fails due to auth/scope/complexity, surface a clear error and suggest narrowing include-paths or reducing chunk size.
+
+### 3) Data flow integration
+- Replace commit+PR collection with:
+  - `pullRequests = fetchMergedPRs()` (GraphQL search + pagination).
+  - If `include-paths` present → `pullRequests = filterByChangedFilesGraphQL(pullRequests)` (batched files queries with cursors and early-exit).
+  - `commits = []` (commit nodes aren’t needed for templates; `$CONTRIBUTORS` is computed from PR authors by release-drafter).
+- Keep using `sortPullRequests` from release-drafter to preserve ordering semantics.
+- Keep using `generateReleaseInfo` unchanged (consumes PR list + config to produce body, including `$CHANGES` and the contributors sentence).
+
+## Compatibility
+- Sorting: `sortPullRequests` (mergedAt/title + direction) unchanged → identical ordering.
+- Categorization/version resolution: requires `labels(first: 100)`; preserved.
+- Template variables: fetch only required fields based on presence in `change-template`.
+- Contributors: `$CONTRIBUTORS` remains correct via PR authors; empty `commits` is acceptable.
+- Avatars/sponsors: JSON output may include enriched fields; templates remain unchanged.
+
+## Edge Cases
+- Time window:
+  - Use `merged:>lastRelease.created_at` for strict greater-than.
+  - If search returns PRs outside the window, filter client-side as a safeguard.
+- No previous release:
+  - Documented behavior: generate notes from “recent” merged PRs (configurable window) or require a baseline tag for full history equivalence. Start with documented behavior, iterate based on usage.
+- Large PRs (files pagination):
+  - For PRs with many files, continue querying with PR-specific cursors. Abort early on first match.
+- GraphQL complexity/rate-limits:
+  - Chunk PRs per query (tunable). On rate-limit, back off and retry respecting reset time.
+
+## Implementation Plan
+- Add `src/graphql/pr-queries.ts`:
+  - Query builder + variables based on config needs (withBody/withURL/withBase/withHead).
+  - `fetchMergedPRs` pagination over the search connection; returns RD-compatible PR nodes.
+- Add `src/graphql/pr-files-queries.ts`:
+  - Build batched files queries with aliases per PR number and per-PR cursor variables.
+  - `filterByChangedFilesGraphQL(prs, includePaths, graphql)` that iterates until matched or files exhausted.
+- Wire into `src/core.ts`:
+  - Always use the PR-only path; if `include-paths` exists, run the GraphQL changed-files filter.
+  - Proceed with `sortPullRequests` + `generateReleaseInfo` as today.
+- Tests:
+  - PR-only fetch path produces expected shape and ordering.
+  - include-paths filtering yields correct inclusion/exclusion against mocked GraphQL files results (with pagination and early-exit).
+  - New contributors tests remain green (separate batched search unchanged).
+
+## Performance Expectations
+- Commit history query eliminated.
+- One GraphQL search (paginated) + batched GraphQL files queries for include-paths.
+- Still significantly lighter than commit-history scans.
+
+## Open Questions
+- Default behavior when no previous release and very large history: adopt a sane default window or expose a `--from` flag. Start with a documentation-first approach.
+
+## Next Steps
+- Implement `fetchMergedPRs` and `filterByChangedFilesGraphQL` and integrate into `core.ts`.
+- Update README with performance notes and include-paths behavior.

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -69,21 +69,7 @@ describe("actionutils/gh-release-notes core", () => {
 					ok: true,
 					status: 200,
 					headers: new Map([["content-type", "application/json"]]),
-					json: async () => ({
-						data: {
-							repository: {
-								object: {
-									history: {
-										nodes: [],
-										pageInfo: {
-											hasNextPage: false,
-											endCursor: null,
-										},
-									},
-								},
-							},
-						},
-					}),
+					json: async () => ({ data: { search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } }),
 				};
 			}
 

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -209,48 +209,25 @@ describe("actionutils/gh-release-notes core", () => {
 			if (u.includes("/graphql")) {
 				graphqlCallCount++;
 
-				// First call: release-drafter's commit/PR fetch
+				// First call: PR search
 				if (graphqlCallCount === 1) {
 					return {
 						ok: true,
 						status: 200,
 						json: async () => ({
 							data: {
-								repository: {
-									object: {
-										history: {
-											nodes: [
-												{
-													author: {
-														user: null,
-													},
-													associatedPullRequests: {
-														nodes: [
-															{
-																number: 10,
-																title: "First PR",
-																url: "https://github.com/owner/repo/pull/10",
-																merged_at: "2024-01-01T00:00:00Z",
-																merged: true,
-																author: {
-																	login: "newuser",
-																	__typename: "User",
-																},
-																labels: { nodes: [] },
-																baseRepository: {
-																	nameWithOwner: `${owner}/${repo}`,
-																},
-															},
-														],
-													},
-												},
-											],
-											pageInfo: {
-												hasNextPage: false,
-												endCursor: null,
-											},
+								search: {
+									pageInfo: { hasNextPage: false, endCursor: null },
+									nodes: [
+										{
+											number: 10,
+											title: "First PR",
+											url: "https://github.com/owner/repo/pull/10",
+											mergedAt: "2024-01-01T00:00:00Z",
+											labels: { nodes: [] },
+											author: { login: "newuser", __typename: "User", url: "" },
 										},
-									},
+									],
 								},
 							},
 						}),
@@ -336,40 +313,25 @@ describe("actionutils/gh-release-notes core", () => {
 			if (u.includes("/graphql")) {
 				graphqlCallCount++;
 
-				// First call: release-drafter's commit/PR fetch
+				// First call: PR search
 				if (graphqlCallCount === 1) {
 					return {
 						ok: true,
 						status: 200,
 						json: async () => ({
 							data: {
-								repository: {
-									object: {
-										history: {
-											nodes: [
-												{
-													author: { user: null },
-													associatedPullRequests: {
-														nodes: [
-															{
-																number: 1,
-																title: "Initial commit",
-																url: "https://github.com/owner/repo/pull/1",
-																merged_at: "2024-01-01T00:00:00Z",
-																merged: true,
-																author: { login: "user1", __typename: "User" },
-																labels: { nodes: [] },
-																baseRepository: {
-																	nameWithOwner: `${owner}/${repo}`,
-																},
-															},
-														],
-													},
-												},
-											],
-											pageInfo: { hasNextPage: false, endCursor: null },
+								search: {
+									pageInfo: { hasNextPage: false, endCursor: null },
+									nodes: [
+										{
+											number: 1,
+											title: "Initial commit",
+											url: "https://github.com/owner/repo/pull/1",
+											mergedAt: "2024-01-01T00:00:00Z",
+											labels: { nodes: [] },
+											author: { login: "user1", __typename: "User", url: "" },
 										},
-									},
+									],
 								},
 							},
 						}),
@@ -392,7 +354,7 @@ describe("actionutils/gh-release-notes core", () => {
 			expect(res.release.body).not.toContain("made their first contribution");
 			expect(res.newContributors).toBeNull();
 
-			// Should have made only 1 GraphQL call (for commits), not 2 (commits + contributors)
+			// Should have made only 1 GraphQL call (for PR search)
 			expect(graphqlCallCount).toBe(1);
 		} finally {
 			// Cleanup
@@ -460,48 +422,29 @@ describe("actionutils/gh-release-notes core", () => {
 			if (u.includes("/graphql")) {
 				graphqlCallCount++;
 
-				// First call: release-drafter's commit/PR fetch
+				// First call: PR search
 				if (graphqlCallCount === 1) {
 					return {
 						ok: true,
 						status: 200,
 						json: async () => ({
 							data: {
-								repository: {
-									object: {
-										history: {
-											nodes: [
-												{
-													author: {
-														user: null,
-													},
-													associatedPullRequests: {
-														nodes: [
-															{
-																number: 20,
-																title: "Bot PR",
-																url: "https://github.com/owner/repo/pull/20",
-																merged_at: "2024-01-02T00:00:00Z",
-																merged: true,
-																author: {
-																	login: "github-actions",
-																	__typename: "Bot",
-																},
-																labels: { nodes: [] },
-																baseRepository: {
-																	nameWithOwner: `${owner}/${repo}`,
-																},
-															},
-														],
-													},
-												},
-											],
-											pageInfo: {
-												hasNextPage: false,
-												endCursor: null,
+								search: {
+									pageInfo: { hasNextPage: false, endCursor: null },
+									nodes: [
+										{
+											number: 20,
+											title: "Bot PR",
+											url: "https://github.com/owner/repo/pull/20",
+											mergedAt: "2024-01-02T00:00:00Z",
+											labels: { nodes: [] },
+											author: {
+												login: "github-actions",
+												__typename: "Bot",
+												url: "",
 											},
 										},
-									},
+									],
 								},
 							},
 						}),

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -69,7 +69,14 @@ describe("actionutils/gh-release-notes core", () => {
 					ok: true,
 					status: 200,
 					headers: new Map([["content-type", "application/json"]]),
-					json: async () => ({ data: { search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } }),
+					json: async () => ({
+						data: {
+							search: {
+								nodes: [],
+								pageInfo: { hasNextPage: false, endCursor: null },
+							},
+						},
+					}),
 				};
 			}
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -353,12 +353,14 @@ export async function run(options: RunOptions) {
 	);
 
 	const sinceDate: string | undefined = lastRelease?.created_at || undefined;
-	const targetCommitishName = targetCommitish.replace(/^refs\/heads\//, "");
+	// Use the repository default branch for base filtering to avoid issues when
+	// targetCommitish is a tag or non-branch ref.
+	const baseBranchName = String(defaultBranch).replace(/^refs\/heads\//, "");
 	let pullRequests: any[] = await fetchMergedPRs({
 		owner,
 		repo,
 		sinceDate,
-		baseBranch: targetCommitishName,
+		baseBranch: baseBranchName,
 		graphqlFn: context.octokit.graphql,
 		withBody: needBody,
 		withURL: needURL,
@@ -511,7 +513,6 @@ export async function run(options: RunOptions) {
 	logVerbose("[Run] Completed successfully");
 	return {
 		release: releaseInfo,
-		commits: [],
 		pullRequests: mergedPullRequestsSorted,
 		categorizedPullRequests,
 		contributors,

--- a/src/core.ts
+++ b/src/core.ts
@@ -23,7 +23,6 @@ import {
 const {
 	validateSchema,
 }: { validateSchema: any } = require("release-drafter/lib/schema");
-// Note: We no longer use release-drafter's commit history scan.
 const {
 	generateReleaseInfo,
 	findReleases,
@@ -338,7 +337,6 @@ export async function run(options: RunOptions) {
 	}
 
 	const targetCommitish: string = target || defaultBranch;
-	// PR-only data path using GraphQL search
 	logVerbose("[GitHub] Resolving merged pull requests via GraphQL search...");
 	const { fetchMergedPRs } = await import("./graphql/pr-queries");
 	const { filterByChangedFilesGraphQL } = await import(
@@ -355,10 +353,12 @@ export async function run(options: RunOptions) {
 	);
 
 	const sinceDate: string | undefined = lastRelease?.created_at || undefined;
+	const targetCommitishName = targetCommitish.replace(/^refs\/heads\//, "");
 	let pullRequests: any[] = await fetchMergedPRs({
 		owner,
 		repo,
 		sinceDate,
+		baseBranch: targetCommitishName,
 		graphqlFn: context.octokit.graphql,
 		withBody: needBody,
 		withURL: needURL,

--- a/src/graphql/pr-files-queries.ts
+++ b/src/graphql/pr-files-queries.ts
@@ -24,7 +24,7 @@ function buildFilesBatchQuery(
       pr_${n}: pullRequest(number: ${n}) {
         files(first: 100, after: $${varPrefix}_pr_${n}) {
           pageInfo { hasNextPage endCursor }
-          nodes { path previousFilePath }
+          nodes { path }
         }
       }
     `,
@@ -82,11 +82,7 @@ export async function filterByChangedFilesGraphQL(
 			let matched = false;
 			for (const f of nodes) {
 				const cur = String(f?.path || "");
-				const prev = String(f?.previousFilePath || "");
-				if (
-					(cur && matchesIncludePaths(cur, includePaths)) ||
-					(prev && matchesIncludePaths(prev, includePaths))
-				) {
+				if (cur && matchesIncludePaths(cur, includePaths)) {
 					matched = true;
 					break;
 				}

--- a/src/graphql/pr-files-queries.ts
+++ b/src/graphql/pr-files-queries.ts
@@ -1,0 +1,111 @@
+type GraphQLFn = (query: string, variables?: any) => Promise<any>;
+
+export type FilterByChangedFilesParams = {
+	owner: string;
+	repo: string;
+	pullRequests: any[];
+	includePaths: string[];
+	graphqlFn: GraphQLFn;
+};
+
+function chunk<T>(arr: T[], size: number): T[][] {
+	const out: T[][] = [];
+	for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+	return out;
+}
+
+function buildFilesBatchQuery(
+	prNumbers: number[],
+	varPrefix = "after",
+): string {
+	const prQueries = prNumbers
+		.map(
+			(n) => `
+      pr_${n}: pullRequest(number: ${n}) {
+        files(first: 100, after: $${varPrefix}_pr_${n}) {
+          pageInfo { hasNextPage endCursor }
+          nodes { path previousFilePath }
+        }
+      }
+    `,
+		)
+		.join("\n");
+	return /* GraphQL */ `
+    query FilesForPRs($owner: String!, $name: String!, ${prNumbers
+			.map((n) => `$${varPrefix}_pr_${n}: String`)
+			.join(", ")}) {
+      repo: repository(owner: $owner, name: $name) {
+        ${prQueries}
+      }
+    }
+  `;
+}
+
+function matchesIncludePaths(path: string, includes: string[]): boolean {
+	for (const p of includes) {
+		if (path.startsWith(p)) return true;
+	}
+	return false;
+}
+
+export async function filterByChangedFilesGraphQL(
+	params: FilterByChangedFilesParams,
+): Promise<any[]> {
+	const { owner, repo, pullRequests, includePaths, graphqlFn } = params;
+	if (includePaths.length === 0 || pullRequests.length === 0)
+		return pullRequests;
+
+	const numbers: number[] = pullRequests
+		.map((p) => p?.number)
+		.filter((n) => typeof n === "number");
+
+	const kept = new Set<number>();
+	const perPrCursors = new Map<number, string | null>();
+	for (const n of numbers) perPrCursors.set(n, null);
+
+	const CHUNK = 20;
+	let pending = new Set(numbers);
+
+	while (pending.size > 0) {
+		const batch = Array.from(pending).slice(0, CHUNK);
+		const query = buildFilesBatchQuery(batch);
+		const variables: any = { owner, name: repo };
+		for (const n of batch) {
+			variables[`after_pr_${n}`] = perPrCursors.get(n) || null;
+		}
+		const data = await graphqlFn(query, variables);
+		const repoNode = data?.repo;
+		for (const n of batch) {
+			const prNode = repoNode?.[`pr_${n}`];
+			const files = prNode?.files;
+			const nodes: any[] = Array.isArray(files?.nodes) ? files.nodes : [];
+			let matched = false;
+			for (const f of nodes) {
+				const cur = String(f?.path || "");
+				const prev = String(f?.previousFilePath || "");
+				if (
+					(cur && matchesIncludePaths(cur, includePaths)) ||
+					(prev && matchesIncludePaths(prev, includePaths))
+				) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) {
+				kept.add(n);
+				pending.delete(n);
+				continue;
+			}
+			const pageInfo = files?.pageInfo;
+			if (pageInfo?.hasNextPage) {
+				perPrCursors.set(n, pageInfo.endCursor || null);
+			} else {
+				// no match and no more pages
+				pending.delete(n);
+			}
+		}
+	}
+
+	const result = pullRequests.filter((p) => kept.has(p.number));
+	return result;
+}

--- a/src/graphql/pr-queries.ts
+++ b/src/graphql/pr-queries.ts
@@ -1,0 +1,91 @@
+export type SearchPRParams = {
+	owner: string;
+	repo: string;
+	sinceDate?: string;
+	graphqlFn: (query: string, variables?: any) => Promise<any>;
+	withBody: boolean;
+	withURL: boolean;
+	withBaseRefName: boolean;
+	withHeadRefName: boolean;
+};
+
+function buildSearchQuery(): string {
+	return /* GraphQL */ `
+    query SearchMergedPRs(
+      $q: String!
+      $withBody: Boolean!
+      $withURL: Boolean!
+      $withBase: Boolean!
+      $withHead: Boolean!
+      $after: String
+    ) {
+      search(query: $q, type: ISSUE, first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          ... on PullRequest {
+            number
+            title
+            mergedAt
+            url @include(if: $withURL)
+            body @include(if: $withBody)
+            baseRefName @include(if: $withBase)
+            headRefName @include(if: $withHead)
+            labels(first: 100) { nodes { name } }
+            author {
+              login
+              __typename
+              url
+              ... on User { avatarUrl sponsorsListing { url } }
+            }
+          }
+        }
+      }
+    }
+  `;
+}
+
+export async function fetchMergedPRs(params: SearchPRParams): Promise<any[]> {
+	const {
+		owner,
+		repo,
+		sinceDate,
+		graphqlFn,
+		withBody,
+		withURL,
+		withBaseRefName,
+		withHeadRefName,
+	} = params;
+
+	const qParts = [`repo:${owner}/${repo}`, `is:pr`, `is:merged`];
+	if (sinceDate) {
+		qParts.push(`merged:>${sinceDate}`);
+	}
+	const q = qParts.join(" ");
+
+	const query = buildSearchQuery();
+	let after: string | null = null;
+	const prs: any[] = [];
+	// paginate search
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const variables = {
+			q,
+			withBody,
+			withURL,
+			withBase: withBaseRefName,
+			withHead: withHeadRefName,
+			after,
+		};
+		const data = await graphqlFn(query, variables);
+		const search = data?.search;
+		const nodes = Array.isArray(search?.nodes) ? search.nodes : [];
+		for (const node of nodes) {
+			// Node is a PullRequest per selection set
+			prs.push(node);
+		}
+		const pageInfo = search?.pageInfo;
+		if (!pageInfo?.hasNextPage) break;
+		after = pageInfo.endCursor || null;
+	}
+	return prs;
+}

--- a/src/graphql/pr-queries.ts
+++ b/src/graphql/pr-queries.ts
@@ -45,7 +45,9 @@ function buildSearchQuery(): string {
   `;
 }
 
-const { paginate }: { paginate: any } = require("release-drafter/lib/pagination");
+const {
+	paginate,
+}: { paginate: any } = require("release-drafter/lib/pagination");
 
 export async function fetchMergedPRs(params: SearchPRParams): Promise<any[]> {
 	const {
@@ -73,7 +75,14 @@ export async function fetchMergedPRs(params: SearchPRParams): Promise<any[]> {
 	const data = await paginate(
 		graphqlFn,
 		query,
-		{ q, withBody, withURL, withBase: withBaseRefName, withHead: withHeadRefName, after: null },
+		{
+			q,
+			withBody,
+			withURL,
+			withBase: withBaseRefName,
+			withHead: withHeadRefName,
+			after: null,
+		},
 		["search"],
 	);
 	const nodes = Array.isArray(data?.search?.nodes) ? data.search.nodes : [];

--- a/src/include-paths.test.ts
+++ b/src/include-paths.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import path from "node:path";
+import * as os from "node:os";
+import * as fsPromises from "node:fs/promises";
+
+describe("include-paths via GraphQL files filter", () => {
+	const sourcePath = path.resolve(import.meta.dir, "./core.ts");
+	const owner = "acme";
+	const repo = "demo";
+
+	let originalFetch: typeof global.fetch;
+
+	beforeEach(() => {
+		process.env.GITHUB_TOKEN = "fake-token";
+		originalFetch = global.fetch;
+	});
+
+	afterEach(() => {
+		delete process.env.GITHUB_TOKEN;
+		global.fetch = originalFetch;
+	});
+
+	test("filters PRs by include-paths using GraphQL PR files", async () => {
+		const tmpDir = await fsPromises.mkdtemp(
+			path.join(os.tmpdir(), "test-inc-"),
+		);
+		const cfgPath = path.join(tmpDir, "config.yml");
+		await fsPromises.writeFile(
+			cfgPath,
+			[
+				"template: '$CHANGES'",
+				"categories:",
+				"  - title: Cat",
+				"    labels: ['cat']",
+				"include-paths:",
+				"  - 'src/keep'",
+			].join("\n"),
+		);
+
+		let graphqlCallCount = 0;
+		global.fetch = mock(async (url: any) => {
+			const u = url.toString();
+			if (u.endsWith(`/repos/${owner}/${repo}`)) {
+				return {
+					ok: true,
+					status: 200,
+					headers: new Map([["content-type", "application/json"]]),
+					json: async () => ({ default_branch: "main" }),
+				} as any;
+			}
+			if (u.includes("/releases")) {
+				return {
+					ok: true,
+					status: 200,
+					headers: new Map([["content-type", "application/json"]]),
+					json: async () => [],
+				} as any;
+			}
+			if (u.includes("/graphql")) {
+				graphqlCallCount++;
+				// 1st: PR search
+				if (graphqlCallCount === 1) {
+					return {
+						ok: true,
+						status: 200,
+						headers: new Map([["content-type", "application/json"]]),
+						json: async () => ({
+							data: {
+								search: {
+									pageInfo: { hasNextPage: false, endCursor: null },
+									nodes: [
+										{
+											number: 1,
+											title: "Touch src/keep",
+											mergedAt: "2024-01-01T00:00:00Z",
+											labels: { nodes: [{ name: "cat" }] },
+											author: { login: "user", __typename: "User", url: "" },
+										},
+										{
+											number: 2,
+											title: "Touch docs",
+											mergedAt: "2024-01-02T00:00:00Z",
+											labels: { nodes: [{ name: "cat" }] },
+											author: { login: "user", __typename: "User", url: "" },
+										},
+									],
+								},
+							},
+						}),
+					} as any;
+				}
+				// 2nd: Files batch for PRs 1 and 2
+				if (graphqlCallCount === 2) {
+					return {
+						ok: true,
+						status: 200,
+						headers: new Map([["content-type", "application/json"]]),
+						json: async () => ({
+							data: {
+								repo: {
+									pr_1: {
+										files: {
+											pageInfo: { hasNextPage: false, endCursor: null },
+											nodes: [
+												{ path: "src/keep/file.ts", previousFilePath: null },
+											],
+										},
+									},
+									pr_2: {
+										files: {
+											pageInfo: { hasNextPage: false, endCursor: null },
+											nodes: [
+												{ path: "docs/readme.md", previousFilePath: null },
+											],
+										},
+									},
+								},
+							},
+						}),
+					} as any;
+				}
+			}
+			throw new Error("Unexpected fetch: " + u);
+		}) as any;
+
+		try {
+			const { run } = await import(sourcePath);
+			const res = await run({ repo: `${owner}/${repo}`, config: cfgPath });
+			const numbers = (res.pullRequests || []).map((p: any) => p.number);
+			expect(numbers).toEqual([1]);
+		} finally {
+			await fsPromises.rm(tmpDir, { recursive: true });
+		}
+	});
+});

--- a/src/sort-pull-requests.test.ts
+++ b/src/sort-pull-requests.test.ts
@@ -60,52 +60,32 @@ describe("PR sorting via release-drafter", () => {
 					"2024-01-02T00:00:00Z",
 					"2024-01-01T00:00:00Z",
 				];
-				// Two PRs with different merged_at and labels
 				return {
 					ok: true,
 					status: 200,
 					headers: new Map([["content-type", "application/json"]]),
 					json: async () => ({
 						data: {
-							repository: {
-								object: {
-									history: {
-										nodes: [
-											{
-												author: { user: null },
-												associatedPullRequests: {
-													nodes: [
-														{
-															number: 2,
-															title: title2,
-															url: "https://github.com/owner/repo/pull/2",
-															mergedAt: mergedAt2,
-															merged: true,
-															author: { login: "user", __typename: "User" },
-															labels: { nodes: [{ name: "cat" }] },
-															baseRepository: {
-																nameWithOwner: `${owner}/${repo}`,
-															},
-														},
-														{
-															number: 1,
-															title: title1,
-															url: "https://github.com/owner/repo/pull/1",
-															mergedAt: mergedAt1,
-															merged: true,
-															author: { login: "user", __typename: "User" },
-															labels: { nodes: [{ name: "cat" }] },
-															baseRepository: {
-																nameWithOwner: `${owner}/${repo}`,
-															},
-														},
-													],
-												},
-											},
-										],
-										pageInfo: { hasNextPage: false, endCursor: null },
+							search: {
+								pageInfo: { hasNextPage: false, endCursor: null },
+								nodes: [
+									{
+										number: 2,
+										title: title2,
+										url: "https://github.com/owner/repo/pull/2",
+										mergedAt: mergedAt2,
+										labels: { nodes: [{ name: "cat" }] },
+										author: { login: "user", __typename: "User", url: "" },
 									},
-								},
+									{
+										number: 1,
+										title: title1,
+										url: "https://github.com/owner/repo/pull/1",
+										mergedAt: mergedAt1,
+										labels: { nodes: [{ name: "cat" }] },
+										author: { login: "user", __typename: "User", url: "" },
+									},
+								],
 							},
 						},
 					}),

--- a/test/changelog-link.test.ts
+++ b/test/changelog-link.test.ts
@@ -64,7 +64,7 @@ describe("Full Changelog Link", () => {
 					ok: true,
 					status: 200,
 					headers,
-					json: async () => ({ data: {} }),
+					json: async () => ({ data: { search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } }),
 				};
 			}
 
@@ -139,7 +139,7 @@ describe("Full Changelog Link", () => {
 					ok: true,
 					status: 200,
 					headers,
-					json: async () => ({ data: {} }),
+					json: async () => ({ data: { search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } }),
 				};
 			}
 
@@ -231,7 +231,7 @@ describe("Full Changelog Link", () => {
 					ok: true,
 					status: 200,
 					headers,
-					json: async () => ({ data: {} }),
+					json: async () => ({ data: { search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } } }),
 				};
 			}
 


### PR DESCRIPTION
  ## Summary

  This PR replaces the commit-history-based query with a lightweight, PR-only GraphQL flow and implements include-
  paths filtering using the PullRequest.files GraphQL connection. It keeps release-drafter compatibility (sorting,
  templates, categorization, contributors) while significantly reducing query cost. Also drops the commits field from
  run() output.

  - Design doc: docs/pr-only-graphql.md
  - Linked issue: #52

  ## Why

  - The commit-history scan + associated PRs is heavy and slow.
  - We only need merged PRs in the relevant window for release notes.
  - include-paths can be implemented without commit history by checking PR changed files.

  ## What Changed

  - Core:
      - Use GraphQL search to fetch merged PRs (no commit history).
      - Filter by include-paths using batched GraphQL PullRequest.files queries.
      - Base branch for PR search is the repository default branch (not target, which can be a tag).
      - Removed commits from run() output (API simplification).
  - GraphQL helpers:
      - src/graphql/pr-queries.ts:
      - `fetchMergedPRs` uses search with `repo:`, `is:pr`, `is:merged`, `base:<default-branch>` and
  `merged:>lastRelease.created_at` (when available).
      - Conditional fields based on template: `$BODY`, `$URL`, `$BASE_REF_NAME`, `$HEAD_REF_NAME`.
      - Uses release-drafter’s `paginate` helper for Relay pagination.
  - src/graphql/pr-files-queries.ts:
      - `filterByChangedFilesGraphQL` batches PRs (aliases) to query `pullRequest.files(first: 100)` and matches `nodes
  { path }` against include-path prefixes.
      - Paginates per-PR when needed; early-exits per PR once a match is found.
  - Tests:
      - Updated mocks to return search-style results (not commit history).
      - Added src/include-paths.test.ts to verify include-paths filtering via GraphQL files.
      - All tests pass: 109 pass / 0 fail.
  - Docs:
      - docs/pr-only-graphql.md (English, with headers + code blocks).

  ## Compatibility

  - release-drafter compatibility is preserved:
      - Sorting: still uses sortPullRequests.
      - Categorization/version resolution: uses labels(first: 100).
      - Templates: fetch conditional fields only when needed.
      - $CONTRIBUTORS: computed from PR authors (commits no longer needed).
  - Breaking change:
      - run() no longer includes commits in the returned object.

  ## Implementation Details

  - PR search query example:
      - repo:OWNER/REPO is:pr is:merged base:<default-branch> merged:>YYYY-MM-DDTHH:MM:SSZ
  - Include-paths:
      - GraphQL: pullRequest(number: N) { files(first: 100, after: $cursor) { nodes { path } pageInfo { ... } } }
      - Matched if any file path starts with any configured include-path.
  - Performance:
      - Removes commit-history pagination; replaces with a single paginated search + batched files queries.

  ## How to Verify

  - Run tests:
      - bun test
  - Manual:
      - Use your GH token in env (GITHUB_TOKEN or GH_TOKEN).
      - Run the CLI with your repo and config, e.g.:
      - `bun run src/cli.ts --repo owner/repo`
      - or `bun run src/cli.ts --repo owner/repo --config .github/release-drafter.yml`
  - Confirm:
      - Release body renders correctly.
      - `$CHANGES` and `$CONTRIBUTORS` work as before.
      - `$NEW_CONTRIBUTORS` behaves as before (when present).
      - include-paths filters PRs as expected.

  ## Follow-ups

  - Optional flag to override base branch if needed.
  - Consider exposing a configurable window when no previous release exists.

  ## Checklist

  - [x] Design doc updated
  - [x] PR-only search implemented
  - [x] include-paths via GraphQL files implemented
  - [x] Tests updated/added and passing
  - [x] Docs in docs/pr-only-graphql.md
  - [x] Linked issue: #52

