### PR TITLE
feat: auto sponsor-fetch-mode to intelligently select fetching method

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ interface Args {
 	"include-new-contributors"?: boolean;
 	// Using enum instead of boolean to allow future extensibility
 	// (e.g., fetching via HTML HEAD requests)
-	"sponsor-fetch-mode"?: "none" | "graphql" | "html";
+	"sponsor-fetch-mode"?: "none" | "graphql" | "html" | "auto";
 }
 
 async function main() {
@@ -79,10 +79,10 @@ async function main() {
 		})
 		.option("sponsor-fetch-mode", {
 			type: "string",
-			choices: ["none", "graphql", "html"] as const,
+			choices: ["none", "graphql", "html", "auto"] as const,
 			description:
-				"How to fetch sponsor information. 'graphql' requires user token (even without any permissions) - GitHub blocks app tokens including GITHUB_TOKEN from accessing this public data. 'html' (experimental) checks sponsor pages via HEAD requests.",
-			default: "none",
+				"How to fetch sponsor information. 'graphql' requires non-GitHub App token (even without any permissions) - GitHub blocks GitHub App tokens (including GITHUB_TOKEN) from accessing this public data. 'html' (experimental) checks sponsor pages via HEAD requests. 'auto' automatically selects the best method based on token type.",
+			default: "auto",
 		})
 		.help("help")
 		.alias("help", "h")
@@ -160,6 +160,7 @@ async function main() {
 			preview: args.preview,
 			includeNewContributors: args["include-new-contributors"],
 			sponsorFetchMode: args["sponsor-fetch-mode"],
+			isJsonMode: args.json,
 		});
 
 		if (args.json) {

--- a/src/graphql/pr-queries.ts
+++ b/src/graphql/pr-queries.ts
@@ -2,14 +2,15 @@
  * Sponsor fetch mode controls how sponsor information is retrieved.
  * Using an enum-like type instead of boolean to allow future extensibility.
  *
- * - 'none': Do not fetch sponsor information (default)
- * - 'graphql': Fetch via GraphQL API (requires user token, even without any permissions)
+ * - 'none': Do not fetch sponsor information
+ * - 'graphql': Fetch via GraphQL API (requires non-GitHub App token, even without any permissions)
  * - 'html': (Experimental) Fetch by making HEAD requests to HTML sponsor pages
+ * - 'auto': Automatically select the best method based on token type and output format
  *
  * Note: We use this approach instead of a simple boolean to accommodate potential
  * future methods of fetching sponsor information without breaking the API.
  */
-export type SponsorFetchMode = "none" | "graphql" | "html";
+export type SponsorFetchMode = "none" | "graphql" | "html" | "auto";
 
 export type SearchPRParams = {
 	owner: string;


### PR DESCRIPTION
## Summary
- Changed default `--sponsor-fetch-mode` from `none` to `auto` for intelligent auto-detection
- Automatically selects the optimal sponsor fetching method based on token type and output format
- Improves user experience by removing the need to manually configure sponsor fetching

## Changes
1. **Auto-detection logic**:
   - Uses `none` when not in JSON output mode (sponsor info is not displayed in markdown output)
   - Uses `html` for GitHub App tokens (`ghs_` prefix, including `GITHUB_TOKEN` in Actions)
   - Uses `graphql` for non-GitHub App tokens (user tokens, OAuth, fine-grained PAT, etc.)

2. **Documentation improvements**:
   - Clarified that GraphQL requires "non-GitHub App token" rather than "user token"
   - Explicitly mentions that `GITHUB_TOKEN` is a GitHub App token

3. **Comprehensive tests**:
   - Added tests for GitHub App token detection
   - Added tests for non-GitHub App token detection
   - Added tests for non-JSON mode behavior

## Test plan
- [x] Unit tests pass (`bun test`)
- [x] Linting passes (`bun run check`)
- [x] Manual testing with different token types shows correct auto-detection

🤖 Generated with [Claude Code](https://claude.ai/code)