### PR TITLE
feat: add full changelog link to JSON output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -200,6 +200,7 @@ async function main() {
 						contributors: result.contributors,
 						newContributors: shapedNewContributors,
 						release: allowlistedRelease,
+						fullChangelogLink: result.fullChangelogLink,
 					},
 					null,
 					2,

--- a/src/core.ts
+++ b/src/core.ts
@@ -339,17 +339,19 @@ export async function run(options: RunOptions) {
 		}
 	}
 
-	// Replace $FULL_CHANGELOG_LINK placeholder in template before processing
+	// Generate full changelog link
+	const previousTag = prevTag || lastRelease?.tag_name;
+	const fullChangelogLink = generateFullChangelogLink({
+		owner,
+		repo,
+		previousTag,
+		nextTag: preview
+			? target || tag || defaultBranch
+			: tag || target || defaultBranch,
+	});
+
+	// Replace $FULL_CHANGELOG_LINK placeholder in template if it exists
 	if (rdConfig.template && rdConfig.template.includes("$FULL_CHANGELOG_LINK")) {
-		const previousTag = prevTag || lastRelease?.tag_name;
-		const fullChangelogLink = generateFullChangelogLink({
-			owner,
-			repo,
-			previousTag,
-			nextTag: preview
-				? target || tag || defaultBranch
-				: tag || target || defaultBranch,
-		});
 		logVerbose(
 			`[Template] Injecting FULL_CHANGELOG_LINK: ${fullChangelogLink}`,
 		);
@@ -590,5 +592,6 @@ export async function run(options: RunOptions) {
 		targetCommitish,
 		owner,
 		repo,
+		fullChangelogLink,
 	};
 }


### PR DESCRIPTION
## Summary
- Added a new `fullChangelogLink` field to the JSON output that contains the GitHub compare URL
- The link is generated once in `core.ts` and reused for both template replacement and JSON output
- Simplified the template check to only control whether to replace the placeholder

## Implementation Details
- The `fullChangelogLink` is generated early in the `run` function in `core.ts`
- It generates:
  - A compare URL (`/compare/prevTag...nextTag`) when a previous tag exists
  - A commits URL (`/commits/tag`) when no previous tag is available
- The generated link is:
  1. Used to replace `$FULL_CHANGELOG_LINK` in templates (if the placeholder exists)
  2. Returned in the result object for use in JSON output

## Test Results
Tested the implementation with:
```bash
# With previous tag
./dist/cli.js --json --preview --tag v1.0.0 | jq -r '.fullChangelogLink'
# Output: https://github.com/actionutils/gh-release-notes/compare/v0.4.0...v1.0.0

# With explicit previous tag
./dist/cli.js --json --preview --tag v0.4.0 --prev-tag v0.3.0 | jq -r '.fullChangelogLink'
# Output: https://github.com/actionutils/gh-release-notes/compare/v0.3.0...v0.4.0
```

Closes #61

🤖 Generated with [Claude Code](https://claude.ai/code)