### PR TITLE
feat: restore version fields in JSON output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -168,21 +168,17 @@ async function main() {
 			// Unlike release-drafter, this tool doesn't create releases, so
 			// fields like `draft` and `make_latest` are meaningless in --json output.
 			// Allowlist only fields meaningful for consumers of this CLI
-			// This avoids leaking release-creation specific or internal fields
-			// from release-drafter internals (e.g., draft, make_latest, prerelease,
-			// resolvedVersion, majorVersion, minorVersion, patchVersion, etc.).
-			const {
-				name,
-				tag,
-				body,
-				targetCommitish: releaseTargetCommitish,
-			} = result.release as any as Record<string, any>;
+			// Include version fields which are useful for creating releases based on this output
 			const allowlistedRelease = {
-				name,
-				tag,
-				body,
-				targetCommitish: releaseTargetCommitish,
-			} as Record<string, any>;
+				name: result.release.name,
+				tag: result.release.tag,
+				body: result.release.body,
+				targetCommitish: result.release.targetCommitish,
+				resolvedVersion: result.release.resolvedVersion,
+				majorVersion: result.release.majorVersion,
+				minorVersion: result.release.minorVersion,
+				patchVersion: result.release.patchVersion,
+			};
 
 			// newContributors is a direct array aligned to contributors shape
 			const shapedNewContributors = result.newContributors;


### PR DESCRIPTION
## Summary
- Restores `resolvedVersion`, `majorVersion`, `minorVersion`, and `patchVersion` fields from release-drafter output to the JSON response
- These fields are useful when users want to create releases based on gh-release-notes output
- Adds test to verify the version fields are correctly included in JSON output

## Test plan
- [x] Added unit test to verify version fields are present in JSON output
- [x] Manually tested with `./dist/cli.js --repo actionutils/gh-release-notes --preview --tag v0.2.0 --json` to confirm fields are populated correctly
- [x] All existing tests pass

Fixes #63

🤖 Generated with [Claude Code](https://claude.ai/code)