### PR TITLE
fix: handle uncategorized PRs properly with github templates

### DIFF
--- a/templates/github-ext.md.jinja
+++ b/templates/github-ext.md.jinja
@@ -19,6 +19,13 @@
 {%- endif %}
 {%- endif %}
 {%- endfor %}
+
+{# Render uncategorized PRs only when no categories are defined (no header) #}
+{%- if (categorizedPullRequests.categories | length == 0) and (categorizedPullRequests.uncategorized | length > 0) %}
+{%- for pr in categorizedPullRequests.uncategorized %}
+- {{ pr.title }} by @{{ pr.author.login }} in [#{{ pr.number }}]({{ pr.url }})
+{%- endfor %}
+{%- endif %}
 {%- if newContributors | length > 0 %}
 
 ## New Contributors

--- a/templates/github.md.jinja
+++ b/templates/github.md.jinja
@@ -1,29 +1,22 @@
 ## What's Changed
-{% for category in categorizedPullRequests.categories %}
+{%- for category in categorizedPullRequests.categories %}
 {%- if category.pullRequests | length > 0 %}
 ### {{ category.title }}
-{%- if category["collapse-after"] and category["collapse-after"] > 0 and category.pullRequests | length > category["collapse-after"] %}
-
-<details>
-<summary>Show all {{ category.pullRequests | length }} items</summary>
-
 {%- for pr in category.pullRequests %}
-- {{ pr.title }} by @{{ pr.author.login }} in {{ pr.url }}
-{%- endfor %}
-
-</details>
-{%- else %}
-{%- for pr in category.pullRequests %}
-- {{ pr.title }} by @{{ pr.author.login }} in {{ pr.url }}
+* {{ pr.title }} by @{{ pr.author.login }} in {{ pr.url }}
 {%- endfor %}
 {%- endif %}
-{%- endif %}
 {%- endfor %}
+{# Render uncategorized PRs only when no categories are defined #}
+{%- if (categorizedPullRequests.categories | length == 0) and (categorizedPullRequests.uncategorized | length > 0) %}
+{%- for pr in categorizedPullRequests.uncategorized %}
+* {{ pr.title }} by @{{ pr.author.login }} in {{ pr.url }}
+{%- endfor %}
+{%- endif %}
 {%- if newContributors | length > 0 %}
-
 ## New Contributors
 {%- for contributor in newContributors %}
-- @{{ contributor.login }} made their first contribution in {{ contributor.firstPullRequest.url }}
+* @{{ contributor.login }} made their first contribution in {{ contributor.firstPullRequest.url }}
 {%- endfor %}
 {%- endif %}
 


### PR DESCRIPTION
also, remove collapse-after handling from templates/github.md.jinja
which should output the same format as GitHub Generate Release Note API
